### PR TITLE
Fix bug with resource_path function

### DIFF
--- a/src/Notifications/NotificationServiceProvider.php
+++ b/src/Notifications/NotificationServiceProvider.php
@@ -21,7 +21,7 @@ class NotificationServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/resources/views' => resource_path('views/vendor/notifications'),
+                __DIR__.'/resources/views' => $this->app->basePath().'/resources/views/vendor/notifications',
             ], 'laravel-notifications');
         }
     }


### PR DESCRIPTION
On version 5.1 Laravel get the error "Call to undefined function Illuminate\Notifications\resource_path()";
