### PR TITLE
Fix bug with composer in NotificationTableCommand

### DIFF
--- a/src/Notifications/Console/NotificationTableCommand.php
+++ b/src/Notifications/Console/NotificationTableCommand.php
@@ -2,8 +2,9 @@
 
 namespace Illuminate\Notifications\Console;
 
+use ReflectionClass;
+use InvalidArgumentException;
 use Illuminate\Console\Command;
-use Illuminate\Support\Composer;
 use Illuminate\Filesystem\Filesystem;
 
 class NotificationTableCommand extends Command
@@ -30,7 +31,7 @@ class NotificationTableCommand extends Command
     protected $files;
 
     /**
-     * @var \Illuminate\Support\Composer
+     * @var mixed
      */
     protected $composer;
 
@@ -38,14 +39,29 @@ class NotificationTableCommand extends Command
      * Create a new notifications table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer    $composer
+     * @param  mixed $composer
      * @return void
      */
-    public function __construct(Filesystem $files, Composer $composer)
+    public function __construct(Filesystem $files, $composer)
     {
         parent::__construct();
 
         $this->files = $files;
+        $composerClass = 'Illuminate\Support\Composer';
+        if (class_exists('Illuminate\Foundation\Composer')) {
+            $composerClass = 'Illuminate\Foundation\Composer';
+        }
+        $reflection = new ReflectionClass($composerClass);
+        if (!is_object($composer) || !$reflection->isInstance($composer)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Argument 2 passed to %s::%s must be an instance of %s',
+                    __CLASS__,
+                    __FUNCTION__,
+                    $composerClass
+                )
+            );
+        }
         $this->composer = $composer;
     }
 


### PR DESCRIPTION
On version 5.1 Laravel get the error

```
[Symfony\Component\Debug\Exception\FatalThrowableError]                                                                                                                                                                                                                                                                                                            
  Type error: Argument 2 passed to Illuminate\Notifications\Console\NotificationTableCommand::__construct() must be an instance of Illuminate\Support\Composer, instance of Illuminate\Foundation\Composer given, called in /home/evgeny/www/old-laravel/vendor/laravel-notification-channels/backport/src/Notifications/NotificationServiceProvider.php on line 58  
```

This error occurs because in version 5.2 moved Illuminate\Foundation\Composer in Illuminate\Support\Composer.
