### PR TITLE
Add support for queueable notifications

### DIFF
--- a/src/Notifications/NotificationServiceProvider.php
+++ b/src/Notifications/NotificationServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Notifications\Console\NotificationTableCommand;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Notifications\Factory as FactoryContract;
 use Illuminate\Contracts\Notifications\Dispatcher as DispatcherContract;
+use Illuminate\Bus\Dispatcher as Bus;
 
 class NotificationServiceProvider extends ServiceProvider
 {
@@ -24,6 +25,10 @@ class NotificationServiceProvider extends ServiceProvider
                 __DIR__.'/resources/views' => $this->app->basePath().'/resources/views/vendor/notifications',
             ], 'laravel-notifications');
         }
+
+        $this->app->make(Bus::class)->maps([
+            SendQueuedNotifications::class => SendQueuedNotificationsHandler::class.'@handle',
+        ]);
     }
 
     /**

--- a/src/Notifications/SendQueuedNotifications.php
+++ b/src/Notifications/SendQueuedNotifications.php
@@ -15,14 +15,14 @@ class SendQueuedNotifications implements ShouldQueue
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $notifiables;
+    public $notifiables;
 
     /**
      * The notification to be sent.
      *
      * @var \Illuminate\Notifications\Notification
      */
-    protected $notification;
+    public $notification;
 
     /**
      * Create a new job instance.

--- a/src/Notifications/SendQueuedNotificationsHandler.php
+++ b/src/Notifications/SendQueuedNotificationsHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+use Illuminate\Support\Facades\Notification as Manager;
+
+class SendQueuedNotificationsHandler
+{
+    /**
+     * Send the notifications.
+     *
+     * @param  \Illuminate\Notifications\SendQueuedNotifications $command
+     * @return void
+     */
+    public function handle(SendQueuedNotifications $command)
+    {
+        Manager::sendNow($command->notifiables, $command->notification);
+    }
+}


### PR DESCRIPTION
if you use the notifications with ShouldQueue on the version 5.1, you will receive the error

```
[InvalidArgumentException]                                                            
  No handler registered for command [Illuminate\Notifications\SendQueuedNotifications]
```
