### PR TITLE
Fix notification serialization issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
+        "illuminate/broadcasting": "5.1.*|5.2.*",
         "illuminate/bus": "5.1.*|5.2.*",
         "illuminate/contracts": "5.1.*|5.2.*",
         "illuminate/support": "5.1.*|5.2.*",
@@ -40,8 +41,7 @@
     "suggest": {
         "guzzlehttp/guzzle": "Required to use the Slack transport.",
         "illuminate/database": "Required to use the database transport (5.1.*|5.2.*).",
-        "nexmo/client": "Required to use the Nexmo transport.",
-        "enniel/illuminate-broadcasting-backport": "Required to use in older versions of Laravel (5.1.*|5.2.*)."
+        "nexmo/client": "Required to use the Nexmo transport."
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/broadcasting": "5.1.*|5.2.*",
         "illuminate/bus": "5.1.*|5.2.*",
         "illuminate/contracts": "5.1.*|5.2.*",
         "illuminate/support": "5.1.*|5.2.*",
@@ -41,7 +40,8 @@
     "suggest": {
         "guzzlehttp/guzzle": "Required to use the Slack transport.",
         "illuminate/database": "Required to use the database transport (5.1.*|5.2.*).",
-        "nexmo/client": "Required to use the Nexmo transport."
+        "nexmo/client": "Required to use the Nexmo transport.",
+        "enniel/illuminate-broadcasting-backport": "Required to use in older versions of Laravel (5.1.*|5.2.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Notifications/ChannelManager.php
+++ b/src/Notifications/ChannelManager.php
@@ -59,9 +59,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            $notification = clone $original;
-
-            $notification->id = (string) Uuid::uuid4();
+            $notificationId = Uuid::uuid4()->toString();
 
             $channels = $notification->via($notifiable);
 
@@ -70,6 +68,10 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
             }
 
             foreach ($channels as $channel) {
+                $notification = clone $original;
+
+                $notification->id = $notificationId;
+
                 if (! $this->shouldSendNotification($notifiable, $notification, $channel)) {
                     continue;
                 }

--- a/src/Notifications/Channels/BroadcastChannel.php
+++ b/src/Notifications/Channels/BroadcastChannel.php
@@ -52,6 +52,10 @@ class BroadcastChannel
      */
     protected function getData($notifiable, Notification $notification)
     {
+        if (method_exists($notification, 'toBroadcast')) {
+            return $notification->toBroadcast($notifiable);
+        }
+
         if (method_exists($notification, 'toArray')) {
             return $notification->toArray($notifiable);
         }


### PR DESCRIPTION
This is basically a porting of [that commit](https://github.com/illuminate/notifications/commit/666522fd943fb878423efdf78c6c4aaa0cc17154), that fixes an issue with notifications' object attribute serialization.

Without that fix, deserialization fails after the first channel.