### PR TITLE
Fix notification serialization issue

### DIFF
--- a/src/Notifications/ChannelManager.php
+++ b/src/Notifications/ChannelManager.php
@@ -59,9 +59,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            $notification = clone $original;
-
-            $notification->id = (string) Uuid::uuid4();
+            $notificationId = Uuid::uuid4()->toString();
 
             $channels = $notification->via($notifiable);
 
@@ -70,6 +68,10 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
             }
 
             foreach ($channels as $channel) {
+                $notification = clone $original;
+
+                $notification->id = $notificationId;
+
                 if (! $this->shouldSendNotification($notifiable, $notification, $channel)) {
                     continue;
                 }


### PR DESCRIPTION
This is basically a copy and paste of [that commit](https://github.com/illuminate/notifications/commit/666522fd943fb878423efdf78c6c4aaa0cc17154), that fixes an issue with notifications' object attribute serialization.

Without that fix, deserialization fails after the first channel.