### PR TITLE
Granular notification queue jobs

### DIFF
--- a/src/Notifications/ChannelManager.php
+++ b/src/Notifications/ChannelManager.php
@@ -50,7 +50,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * @param  mixed  $notification
      * @return void
      */
-    public function sendNow($notifiables, $notification)
+    public function sendNow($notifiables, $notification, array $channels = null)
     {
         if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
             $notifiables = [$notifiables];
@@ -63,7 +63,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
 
             $notification->id = (string) Uuid::uuid4();
 
-            $channels = $notification->via($notifiable);
+            $channels = $channels ?: $notification->via($notifiable);
 
             if (empty($channels)) {
                 continue;
@@ -114,12 +114,22 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
                     ->delay($notification->delay)
             );
         } else {
-            $this->app->make(Bus::class)->dispatch(
-                (new SendQueuedNotifications($notifiables, $notification))
-                    ->onConnection($notification->connection)
-                    ->onQueue($notification->queue)
-                    ->delay($notification->delay)
-            );
+            if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
+                $notifiables = [$notifiables];
+            }
+
+            $bus = $this->app->make(Bus::class);
+
+            foreach ($notifiables as $notifiable) {
+                foreach ($notification->via($notifiable) as $channel) {
+                    $bus->dispatch(
+                        (new SendQueuedNotifications($notifiables, $notification, [$channel]))
+                            ->onConnection($notification->connection)
+                            ->onQueue($notification->queue)
+                            ->delay($notification->delay)
+                    );
+                }
+            }
         }
     }
 

--- a/src/Notifications/SendQueuedNotifications.php
+++ b/src/Notifications/SendQueuedNotifications.php
@@ -24,6 +24,8 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public $notification;
 
+    protected $channels = null;
+
     /**
      * Create a new job instance.
      *
@@ -31,8 +33,9 @@ class SendQueuedNotifications implements ShouldQueue
      * @param  \Illuminate\Notifications\Notification  $notification
      * @return void
      */
-    public function __construct($notifiables, $notification)
+    public function __construct($notifiables, $notification, array $channels = null)
     {
+        $this->channels = $channels;
         $this->notifiables = $notifiables;
         $this->notification = $notification;
     }
@@ -45,6 +48,6 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function handle(ChannelManager $manager)
     {
-        $manager->sendNow($this->notifiables, $this->notification);
+        $manager->sendNow($this->notifiables, $this->notification, $this->channels);
     }
 }

--- a/tests/NotificationSendQueuedNotificationTest.php
+++ b/tests/NotificationSendQueuedNotificationTest.php
@@ -13,7 +13,7 @@ class NotificationSendQueuedNotificationTest extends PHPUnit_Framework_TestCase
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');
         $manager = Mockery::mock('Illuminate\Notifications\ChannelManager');
-        $manager->shouldReceive('sendNow')->once()->with('notifiables', 'notification');
+        $manager->shouldReceive('sendNow')->once()->with('notifiables', 'notification', null);
         $job->handle($manager);
     }
 }


### PR DESCRIPTION
Reference: https://github.com/laravel/framework/pull/15681/commits

This tweaks notification queued job to queue a job for each notifiable
/ channel combination. The reason for this is with the prior setup of
using a single job, if one channel fails to send and the job retries
all channels you could deliver duplicate/N number of notifications on a
given channel, possibly costing you money if the channel charges money
per notification.

Signed-off-by: Fairuz Wan Ismail <fairuz.ismail@nazrol.tech>