### PR TITLE
Fix getAppVersion()

### DIFF
--- a/src/Notifications/NotificationServiceProvider.php
+++ b/src/Notifications/NotificationServiceProvider.php
@@ -80,7 +80,7 @@ class NotificationServiceProvider extends ServiceProvider
     {
         $version = $this->app->version();
         if (substr($version, 0, 7) === 'Lumen (') {
-            $version = array_first(explode(')', str_replace('Lumen (', '', $version)));
+            $version = head(explode(')', str_replace('Lumen (', '', $version)));
         }
         return $version;
     }


### PR DESCRIPTION
The PR https://github.com/laravel-notification-channels/backport/pull/12 has a bug, at least in my lumen (5.1.7).

Fixes a `Too few arguments to function array_first()` error. In Lumen 5.1.7, `array_first` requires 2 arguments.